### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set VERSION env
-      run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF:11})
+      run: echo VERSION=${GITHUB_REF:11} >> $GITHUB_ENV
     - name: Build addon with HEMTT
       uses: 16AAModTeam/hemtt@stable
       with:


### PR DESCRIPTION
set-env is deprecated
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/