### PR TITLE
Fixed incorrect error log path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,8 @@ echo "$(cat ./workshop.vdf)"
     echo /home/steam/Steam/logs/stderr.txt
     echo "$(cat /home/steam/Steam/logs/stderr.txt)"
     echo
-    echo /home/steam/Steam/logs/Workshop_log.txt
-    echo "$(cat /home/steam/Steam/logs/Workshop_log.txt)"
+    echo /home/steam/Steam/logs/workshop_log.txt
+    echo "$(cat /home/steam/Steam/logs/workshop_log.txt)"
     echo
     echo /home/steam/Steam/workshopbuilds/depot_build_$1.log
     echo "$(cat /home/steam/Steam/workshopbuilds/depot_build_$1.log)"


### PR DESCRIPTION
```
steam@f38aa91dd597:~/steamcmd$ ls -l /home/steam/Steam/logs
total 72
-rwxr-xr-x 1 steam steam  2002 Mar 14 21:43 appinfo_log.txt
-rwxr-xr-x 1 steam steam 10892 Mar 14 21:43 bootstrap_log.txt
-rwxr-xr-x 1 steam steam  3485 Mar 14 21:43 cloud_log.txt
-rwxr-xr-x 1 steam steam  9630 Mar 14 21:43 compat_log.txt
-rwxr-xr-x 1 steam steam  2293 Mar 14 21:43 configstore_log.txt
-rwxr-xr-x 1 steam steam  7139 Mar 14 21:43 connection_log.txt
-rwxr-xr-x 1 steam steam   220 Mar 14 21:43 content_log.txt
-rwxr-xr-x 1 steam steam   481 Mar 14 21:43 parental_log.txt
-rwxr-xr-x 1 steam steam   393 Mar 14 21:43 remote_steamcmd.txt
-rwxr-xr-x 1 steam steam   234 Mar 14 21:43 shader_log.txt
-rw-r--r-- 1 steam steam    68 Mar 14 21:43 stderr.txt
-rwxr-xr-x 1 steam steam   432 Mar 14 21:43 systemmanager.txt
-rwxr-xr-x 1 steam steam   785 Mar 14 21:43 workshop_log.txt

```